### PR TITLE
Updating Java download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A [video tutorial](https://youtu.be/dOwkInn6eDw) covering the instructions below
 
 The easiest way to run the program on Windows is by using the executable file located in the [releases](https://github.com/Verisimilitude11/DNAnalyzer/releases/latest) section to install the program, build gradle and run the GUI.
 
-* Note: Ensure you have Java [17](https://www.oracle.com/java/technologies/downloads/#jdk17-windows) or higher installed and a `JAVA_HOME` path variable set for the program to function correctly!
+* Note: Ensure you have Java [17](https://www.oracle.com/java/technologies/downloads/#java17) or higher installed and a `JAVA_HOME` path variable set for the program to function correctly!
 
 We use [Gradle](https://gradle.org) for building. The Gradle wrapper takes care of downloading dependencies, testing, compiling, linking, and packaging the code.
 


### PR DESCRIPTION
Java updated it's link naming scheme so that when someone clicks this link, it actually goes to the Java 20 version instead of the Java 17 version.