### PR TITLE
Add a filter to mutate() to exclude unknown bases, add new checks to validate

### DIFF
--- a/src/main/java/DNAnalyzer/core/DNAMutation.java
+++ b/src/main/java/DNAnalyzer/core/DNAMutation.java
@@ -67,17 +67,26 @@ public class DNAMutation {
   private static String mutate(String dnaString, int numMutations) {
     StringBuilder mutatedDna = new StringBuilder(dnaString);
 
-    if (numMutations > mutatedDna.length()) {
-      System.out.println(
-          "Warning: Number of requested mutations exceeds DNA length. Limiting to "
-              + mutatedDna.length());
-      numMutations = mutatedDna.length();
-    }
-
-    // Create a list of all possible positions
+    // Create a list of all possible positions, ignoring unknown bases
     List<Integer> availablePositions = new ArrayList<>();
     for (int i = 0; i < dnaString.length(); i++) {
+      char base = dnaString.charAt(i);
+      if (base == 'n' || base == 'N') {
+        continue; // Skip
+      }
       availablePositions.add(i);
+    }
+
+    if (availablePositions.isEmpty()) {
+      System.out.println("Warning: No valid bases in DNA available for mutation.");
+      return dnaString; // Return the original string, unchanged
+    }
+    
+    if (numMutations > availablePositions.length()) {
+      System.out.println(
+          "Warning: Number of requested mutations exceeds the number of valid bases. Limiting to "
+              + availablePositions.length());
+      numMutations = availablePositions.length();
     }
 
     // Perform mutations


### PR DESCRIPTION
Addresses #475 

I added a filter in mutate() to exclude unknown bases from consideration for mutation.

However, this means the amount of available bases to mutate could be less than the requested number of mutations, so I also limited the number of mutations to the number of available mutatable positions if necessary. I consolidated the old warning re: mutations exceeding the DNA string length with a new warning accounting for the DNA string possibly being shorter due to unknown bases being excluded from consideration.

Also, there is the extreme edge case that the entire string has no valid bases for mutation (which would mean the entire provided DNA string consists of unknown bases), so I added a check for the resulting available bases array being empty, in which case the original DNA string is just returned unchanged. Perhaps there's another way to handle that, though, as with the current way everything is setup, this would output the original string as the "mutation", which isn't ideal as no mutation would have actually occurred, plus the original string would be written to the output file 10x leading to a lot of unnecessary, useless outputting. Could return "null" instead, or an empty String object.