### PR TITLE
Remove API server offline popup from analyzer page

### DIFF
--- a/web/analyzer/analyzer.js
+++ b/web/analyzer/analyzer.js
@@ -291,9 +291,6 @@ function checkAPIStatus() {
                     <span>API Offline - Using Fallback Mode</span>
                 </div>
             `;
-            
-            // Show notice about server setup
-            showNotification('API server is offline. Running in fallback mode with limited functionality.', 'warning', 8000);
         });
 }
 


### PR DESCRIPTION
Remove the pop-up message "API server is offline. Running in fallback mode with limited functionality." from the analyzer page.

* Remove the call to `showNotification` with the message in the `checkAPIStatus` function in `web/analyzer/analyzer.js`
* Remove the `showNotification` function call in the `checkAPIStatus` function in `web/analyzer/analyzer.js`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VerisimilitudeX/DNAnalyzer/pull/492?shareId=107f862a-d8dd-4cb3-afa9-2166100fb6ce).