### PR TITLE
Fix unknown base constants

### DIFF
--- a/src/main/java/DNAnalyzer/core/DNAAnalysis.java
+++ b/src/main/java/DNAnalyzer/core/DNAAnalysis.java
@@ -214,11 +214,13 @@ public record DNAAnalysis(DNATools dna, String protein, String aminoAcid) {
     public static final int UPPERCASE_T = 84;
     public static final int UPPERCASE_G = 71;
     public static final int UPPERCASE_C = 67;
-    public static final int UPPERCASE_UNKNOWN = 0;
+    // ASCII value for 'N'
+    public static final int UPPERCASE_UNKNOWN = 78;
     public static final int LOWERCASE_A = 97;
     public static final int LOWERCASE_T = 116;
     public static final int LOWERCASE_G = 103;
     public static final int LOWERCASE_C = 99;
-    public static final int LOWERCASE_UNKNOWN = 0;
+    // ASCII value for 'n'
+    public static final int LOWERCASE_UNKNOWN = 110;
   }
 }

--- a/src/test/java/DNAnalyzer/core/DNAAnalysisTest.java
+++ b/src/test/java/DNAnalyzer/core/DNAAnalysisTest.java
@@ -34,4 +34,12 @@ class DNAAnalysisTest {
     long[] actual = DNAAnalysis.countBasePairs(null);
     assertArrayEquals(expected, actual);
   }
+
+  @Test
+  void testCountBasePairsWithUnknownBases() {
+    String dnaString = "AaTtGgCcNn";
+    long[] expected = {2, 2, 2, 2, 2};
+    long[] actual = DNAAnalysis.countBasePairs(dnaString);
+    assertArrayEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
## Summary
- set ASCII values for unknown bases 'N' and 'n'
- verify counting of unknown bases in DNAAnalysisTest

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '2.7.5'] was not found)*