### PR TITLE
Implement AI Trait Predictor Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Refer to our comprehensive [Getting Started Guide](docs/getting-started.md) for 
 | **Optimized SQL Database** | Scalable database for genomic datasets across diverse species |
 | **Enhanced Neural Network** | Integration with 3rd-party genotype datasets (23andMe, AncestryDNA) |
 | **DIAMOND Implementation** | Blending DIAMOND's speed with BLAST’s accuracy for cutting-edge analyses |
+| **Secure Share & Compare** | Offline-generated, QR-coded summaries let users share limited insights with doctors or friends—no raw genome ever exposed. |
+| **AI Trait Predictor Suite** | Fun, shareable predictions—taste for cilantro, chronotype, ear-wax type—backed by peer-reviewed SNP studies |
 
 </div>
 

--- a/src/main/java/DNAnalyzer/core/DNAAnalysis.java
+++ b/src/main/java/DNAnalyzer/core/DNAAnalysis.java
@@ -11,22 +11,22 @@
 
 package DNAnalyzer.core;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Map;
-import DNAnalyzer.data.trait.TraitPrediction;
-import DNAnalyzer.data.trait.TraitPredictor;
 import static java.util.Optional.ofNullable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import DNAnalyzer.data.codon.CodonFrame;
+import DNAnalyzer.data.trait.TraitPrediction;
+import DNAnalyzer.data.trait.TraitPredictor;
 import DNAnalyzer.utils.core.BasePairCounter;
 import DNAnalyzer.utils.core.DNATools;
 import DNAnalyzer.utils.core.ReadingFrames;
 import DNAnalyzer.utils.protein.ProteinAnalysis;
 import DNAnalyzer.utils.protein.ProteinFinder;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides functionality to analyze the DNA

--- a/src/main/java/DNAnalyzer/core/DNAAnalysis.java
+++ b/src/main/java/DNAnalyzer/core/DNAAnalysis.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
+import DNAnalyzer.data.trait.TraitPrediction;
+import DNAnalyzer.data.trait.TraitPredictor;
 import static java.util.Optional.ofNullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,7 +80,13 @@ public record DNAAnalysis(DNATools dna, String protein, String aminoAcid) {
     try {
       Map<String, String> data23andMe = DNADataUploader.uploadFrom23andMe(filePath);
       System.out.println("23andMe data loaded. Total SNPs: " + data23andMe.size());
-      // Perform further analysis with data23andMe
+      // Perform simple trait prediction
+      List<TraitPrediction> traitResults = TraitPredictor.predictTraits(data23andMe);
+      System.out.println("Trait predictions:");
+      for (TraitPrediction result : traitResults) {
+        System.out.println(
+            result.trait() + ": " + result.prediction() + " (" + result.genotype() + ")");
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/DNAnalyzer/data/trait/Trait.java
+++ b/src/main/java/DNAnalyzer/data/trait/Trait.java
@@ -1,11 +1,5 @@
 package DNAnalyzer.data.trait;
 
-/**
- * Simple record representing a trait prediction rule.
- */
+/** Simple record representing a trait prediction rule. */
 public record Trait(
-    String name,
-    String snp,
-    String allele,
-    String positivePrediction,
-    String negativePrediction) {}
+    String name, String snp, String allele, String positivePrediction, String negativePrediction) {}

--- a/src/main/java/DNAnalyzer/data/trait/Trait.java
+++ b/src/main/java/DNAnalyzer/data/trait/Trait.java
@@ -1,0 +1,11 @@
+package DNAnalyzer.data.trait;
+
+/**
+ * Simple record representing a trait prediction rule.
+ */
+public record Trait(
+    String name,
+    String snp,
+    String allele,
+    String positivePrediction,
+    String negativePrediction) {}

--- a/src/main/java/DNAnalyzer/data/trait/TraitPrediction.java
+++ b/src/main/java/DNAnalyzer/data/trait/TraitPrediction.java
@@ -1,0 +1,9 @@
+package DNAnalyzer.data.trait;
+
+/**
+ * Represents a predicted trait for a given genotype.
+ */
+public record TraitPrediction(
+    String trait,
+    String genotype,
+    String prediction) {}

--- a/src/main/java/DNAnalyzer/data/trait/TraitPrediction.java
+++ b/src/main/java/DNAnalyzer/data/trait/TraitPrediction.java
@@ -1,9 +1,4 @@
 package DNAnalyzer.data.trait;
 
-/**
- * Represents a predicted trait for a given genotype.
- */
-public record TraitPrediction(
-    String trait,
-    String genotype,
-    String prediction) {}
+/** Represents a predicted trait for a given genotype. */
+public record TraitPrediction(String trait, String genotype, String prediction) {}

--- a/src/main/java/DNAnalyzer/data/trait/TraitPredictor.java
+++ b/src/main/java/DNAnalyzer/data/trait/TraitPredictor.java
@@ -4,51 +4,44 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Predicts simple phenotypic traits from SNP data.
- */
+/** Predicts simple phenotypic traits from SNP data. */
 public class TraitPredictor {
 
-    private static final List<Trait> TRAITS = List.of(
-        new Trait(
-            "Cilantro Preference",
-            "rs72921001",
-            "A",
-            "Likely perceives cilantro as soapy",
-            "No strong cilantro aversion"),
-        new Trait(
-            "Chronotype",
-            "rs11121022",
-            "G",
-            "Predisposed to be a morning person",
-            "Predisposed to be an evening person"),
-        new Trait(
-            "Earwax Type",
-            "rs17822931",
-            "A",
-            "Dry earwax type",
-            "Wet earwax type")
-    );
+  private static final List<Trait> TRAITS =
+      List.of(
+          new Trait(
+              "Cilantro Preference",
+              "rs72921001",
+              "A",
+              "Likely perceives cilantro as soapy",
+              "No strong cilantro aversion"),
+          new Trait(
+              "Chronotype",
+              "rs11121022",
+              "G",
+              "Predisposed to be a morning person",
+              "Predisposed to be an evening person"),
+          new Trait("Earwax Type", "rs17822931", "A", "Dry earwax type", "Wet earwax type"));
 
-    private TraitPredictor() {}
+  private TraitPredictor() {}
 
-    /**
-     * Predict traits from a map of SNP identifiers to genotypes.
-     *
-     * @param snpData SNP genotype map
-     * @return list of trait predictions
-     */
-    public static List<TraitPrediction> predictTraits(Map<String, String> snpData) {
-        List<TraitPrediction> results = new ArrayList<>();
-        for (Trait trait : TRAITS) {
-            String genotype = snpData.get(trait.snp());
-            if (genotype == null) {
-                continue;
-            }
-            boolean match = genotype.contains(trait.allele());
-            String prediction = match ? trait.positivePrediction() : trait.negativePrediction();
-            results.add(new TraitPrediction(trait.name(), genotype, prediction));
-        }
-        return results;
+  /**
+   * Predict traits from a map of SNP identifiers to genotypes.
+   *
+   * @param snpData SNP genotype map
+   * @return list of trait predictions
+   */
+  public static List<TraitPrediction> predictTraits(Map<String, String> snpData) {
+    List<TraitPrediction> results = new ArrayList<>();
+    for (Trait trait : TRAITS) {
+      String genotype = snpData.get(trait.snp());
+      if (genotype == null) {
+        continue;
+      }
+      boolean match = genotype.contains(trait.allele());
+      String prediction = match ? trait.positivePrediction() : trait.negativePrediction();
+      results.add(new TraitPrediction(trait.name(), genotype, prediction));
     }
+    return results;
+  }
 }

--- a/src/main/java/DNAnalyzer/data/trait/TraitPredictor.java
+++ b/src/main/java/DNAnalyzer/data/trait/TraitPredictor.java
@@ -1,0 +1,54 @@
+package DNAnalyzer.data.trait;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Predicts simple phenotypic traits from SNP data.
+ */
+public class TraitPredictor {
+
+    private static final List<Trait> TRAITS = List.of(
+        new Trait(
+            "Cilantro Preference",
+            "rs72921001",
+            "A",
+            "Likely perceives cilantro as soapy",
+            "No strong cilantro aversion"),
+        new Trait(
+            "Chronotype",
+            "rs11121022",
+            "G",
+            "Predisposed to be a morning person",
+            "Predisposed to be an evening person"),
+        new Trait(
+            "Earwax Type",
+            "rs17822931",
+            "A",
+            "Dry earwax type",
+            "Wet earwax type")
+    );
+
+    private TraitPredictor() {}
+
+    /**
+     * Predict traits from a map of SNP identifiers to genotypes.
+     *
+     * @param snpData SNP genotype map
+     * @return list of trait predictions
+     */
+    public static List<TraitPrediction> predictTraits(Map<String, String> snpData) {
+        List<TraitPrediction> results = new ArrayList<>();
+        for (Trait trait : TRAITS) {
+            String genotype = snpData.get(trait.snp());
+            if (genotype == null) {
+                continue;
+            }
+            boolean match = genotype.contains(trait.allele());
+            String prediction = match ? trait.positivePrediction() : trait.negativePrediction();
+            results.add(new TraitPrediction(trait.name(), genotype, prediction));
+        }
+        return results;
+    }
+}

--- a/src/test/java/DNAnalyzer/data/trait/TraitPredictorTest.java
+++ b/src/test/java/DNAnalyzer/data/trait/TraitPredictorTest.java
@@ -11,13 +11,7 @@ class TraitPredictorTest {
   @Test
   void shouldPredictTraitsFromSnpData() {
     Map<String, String> snpData =
-        Map.of(
-            "rs72921001",
-            "AA",
-            "rs11121022",
-            "GG",
-            "rs17822931",
-            "AA");
+        Map.of("rs72921001", "AA", "rs11121022", "GG", "rs17822931", "AA");
 
     List<TraitPrediction> results = TraitPredictor.predictTraits(snpData);
 

--- a/src/test/java/DNAnalyzer/data/trait/TraitPredictorTest.java
+++ b/src/test/java/DNAnalyzer/data/trait/TraitPredictorTest.java
@@ -1,0 +1,29 @@
+package DNAnalyzer.data.trait;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TraitPredictorTest {
+
+  @Test
+  void shouldPredictTraitsFromSnpData() {
+    Map<String, String> snpData =
+        Map.of(
+            "rs72921001",
+            "AA",
+            "rs11121022",
+            "GG",
+            "rs17822931",
+            "AA");
+
+    List<TraitPrediction> results = TraitPredictor.predictTraits(snpData);
+
+    assertEquals(3, results.size());
+    assertEquals("Likely perceives cilantro as soapy", results.get(0).prediction());
+    assertEquals("Predisposed to be a morning person", results.get(1).prediction());
+    assertEquals("Dry earwax type", results.get(2).prediction());
+  }
+}


### PR DESCRIPTION
## Summary
- add AI Trait Predictor Suite to README roadmap alongside Secure Share & Compare
- implement trait prediction logic
- expose predictions when analyzing 23andMe data
- test trait predictor functionality

## Testing
- `./gradlew test` *(fails: No route to host)*