### PR TITLE
Add trait predictions and PRS CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,14 @@ Refer to our comprehensive [Getting Started Guide](docs/getting-started.md) for 
 <br>
 ## Polygenic Health-Risk Scores
 
-DNAnalyzer now includes a lightweight polygenic risk score calculator. Supply a CSV file of SNP weights
-and your genotyping data to estimate risk for complex diseases directly on device.
+DNAnalyzer now includes a lightweight polygenic risk score calculator and fun trait predictions.
+Provide a 23andMe text file along with a CSV of SNP weights to compute scores and see traits:
+
+```bash
+./gradlew run --args='--23andme my_data.txt --prs assets/risk/heart_disease_prs.csv sample.fa'
+```
+
+Trait predictions and the risk score are printed after the standard DNA analysis.
 <br>
 
 

--- a/assets/risk/heart_disease_prs.csv
+++ b/assets/risk/heart_disease_prs.csv
@@ -1,0 +1,4 @@
+#SNP,RiskAllele,Weight
+rs6025,A,1.5
+rs1799983,T,1.2
+rs7412,C,0.8

--- a/src/main/java/DNAnalyzer/data/trait/TraitPredictor.java
+++ b/src/main/java/DNAnalyzer/data/trait/TraitPredictor.java
@@ -33,7 +33,20 @@ public class TraitPredictor {
               "rs762551",
               "A",
               "High caffeine sensitivity",
-              "Lower caffeine sensitivity"));
+              "Lower caffeine sensitivity"),
+          // Additional fun trait predictions
+          new Trait(
+              "Muscle Performance",
+              "rs1815739",
+              "T",
+              "Enhanced sprint/power potential",
+              "Typical muscle performance"),
+          new Trait(
+              "Alcohol Flush Reaction",
+              "rs671",
+              "A",
+              "Likely to experience facial flushing when drinking",
+              "Unlikely to experience flush reaction"));
 
   private TraitPredictor() {}
 

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -14,10 +14,10 @@ package DNAnalyzer.ui.cli;
 import static DNAnalyzer.data.Parser.parseFile;
 
 import DNAnalyzer.core.DNAAnalysis;
-import DNAnalyzer.core.DNAMutation;
-import DNAnalyzer.core.Properties;
 import DNAnalyzer.core.DNADataUploader;
+import DNAnalyzer.core.DNAMutation;
 import DNAnalyzer.core.PolygenicRiskCalculator;
+import DNAnalyzer.core.Properties;
 import DNAnalyzer.data.trait.TraitPrediction;
 import DNAnalyzer.data.trait.TraitPredictor;
 import DNAnalyzer.qc.QcStats;

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -16,12 +16,18 @@ import static DNAnalyzer.data.Parser.parseFile;
 import DNAnalyzer.core.DNAAnalysis;
 import DNAnalyzer.core.DNAMutation;
 import DNAnalyzer.core.Properties;
+import DNAnalyzer.core.DNADataUploader;
+import DNAnalyzer.core.PolygenicRiskCalculator;
+import DNAnalyzer.data.trait.TraitPrediction;
+import DNAnalyzer.data.trait.TraitPredictor;
 import DNAnalyzer.qc.QcStats;
 import DNAnalyzer.ui.gui.DNAnalyzerGUI;
 import DNAnalyzer.utils.core.DNATools;
 import DNAnalyzer.utils.core.Utils;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -118,6 +124,16 @@ public class CmdArgs implements Runnable {
       description = "Window size for GC content calculation")
   Integer gcWindow;
 
+  @Option(
+      names = {"--23andme"},
+      description = "Path to a 23andMe genotype file for trait analysis")
+  File genotypeFile;
+
+  @Option(
+      names = {"--prs"},
+      description = "CSV of SNP weights for polygenic risk scoring")
+  File prsWeights;
+
   /**
    * Output a list of proteins, GC content, Nucleotide content, and other information found in a DNA
    * sequence.
@@ -176,6 +192,25 @@ public class CmdArgs implements Runnable {
             .printProteins(System.out)
             .printHighCoverageRegions(System.out)
             .printLongestProtein(System.out);
+      }
+
+      if (genotypeFile != null) {
+        try {
+          Map<String, String> snps = DNADataUploader.uploadFrom23andMe(genotypeFile.getPath());
+          List<TraitPrediction> traits = TraitPredictor.predictTraits(snps);
+          System.out.println("\nTrait Predictions:");
+          for (TraitPrediction t : traits) {
+            System.out.println(t.trait() + ": " + t.prediction() + " (" + t.genotype() + ")");
+          }
+          if (prsWeights != null) {
+            Map<String, PolygenicRiskCalculator.RiskWeight> weights =
+                PolygenicRiskCalculator.loadWeights(prsWeights.getPath());
+            double score = PolygenicRiskCalculator.computeScore(snps, weights);
+            System.out.printf("Polygenic Risk Score: %.3f%n", score);
+          }
+        } catch (IOException e) {
+          System.err.println("Error processing genotype data: " + e.getMessage());
+        }
       }
 
       if (Properties.isRandomDNA(dnaAnalyzer.dna().getDna())) {

--- a/src/test/java/DNAnalyzer/data/trait/TraitPredictorTest.java
+++ b/src/test/java/DNAnalyzer/data/trait/TraitPredictorTest.java
@@ -21,15 +21,21 @@ class TraitPredictorTest {
             "rs4988235",
             "AA",
             "rs762551",
-            "AA");
+            "AA",
+            "rs1815739",
+            "TT",
+            "rs671",
+            "AG");
 
     List<TraitPrediction> results = TraitPredictor.predictTraits(snpData);
 
-    assertEquals(5, results.size());
+    assertEquals(7, results.size());
     assertEquals("Likely perceives cilantro as soapy", results.get(0).prediction());
     assertEquals("Predisposed to be a morning person", results.get(1).prediction());
     assertEquals("Dry earwax type", results.get(2).prediction());
     assertEquals("Likely lactose tolerant", results.get(3).prediction());
     assertEquals("High caffeine sensitivity", results.get(4).prediction());
+    assertEquals("Enhanced sprint/power potential", results.get(5).prediction());
+    assertEquals("Likely to experience facial flushing when drinking", results.get(6).prediction());
   }
 }


### PR DESCRIPTION
## Summary
- expand `TraitPredictor` with muscle performance and alcohol flush traits
- add 23andMe genotype and PRS options to command line
- compute trait predictions and polygenic risk score in CLI
- include sample heart disease weight file
- document usage for new features in README

## Testing
- `./gradlew test` *(fails: No route to host while downloading gradle)*