### PR TITLE
Add affine gap alignment algorithm

### DIFF
--- a/src/main/java/DNAnalyzer/server/ApiController.java
+++ b/src/main/java/DNAnalyzer/server/ApiController.java
@@ -2,6 +2,7 @@ package DNAnalyzer.server;
 
 import DNAnalyzer.core.DNAAnalysis;
 import DNAnalyzer.utils.core.DNATools;
+import DNAnalyzer.utils.alignment.SequenceAligner;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
@@ -72,6 +73,47 @@ public class ApiController {
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
           .body(Map.of("error", "Analysis failed", "message", e.getMessage()));
+    }
+  }
+
+  @PostMapping(value = "/align", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<?> align(
+      @RequestParam("query") MultipartFile query,
+      @RequestParam("reference") MultipartFile reference) {
+    try {
+      if (query.isEmpty() || reference.isEmpty()) {
+        return ResponseEntity.badRequest()
+            .body(Map.of("error", "Files empty", "message", "Provide both FASTA files"));
+      }
+      Path qTemp = Files.createTempFile("query-", ".fa");
+      Path rTemp = Files.createTempFile("ref-", ".fa");
+      query.transferTo(qTemp.toFile());
+      reference.transferTo(rTemp.toFile());
+
+      try {
+        String qSeq = Files.readString(qTemp);
+        String rSeq = Files.readString(rTemp);
+
+        if (!isValidDNASequence(qSeq) || !isValidDNASequence(rSeq)) {
+          return ResponseEntity.badRequest()
+              .body(
+                  Map.of(
+                      "error", "Invalid sequence", "message", "Sequences contain invalid DNA characters"));
+        }
+
+        var result = SequenceAligner.align(qSeq, rSeq);
+        Map<String, Object> resp = new HashMap<>();
+        resp.put("score", result.score());
+        resp.put("alignedQuery", result.alignedSeq1());
+        resp.put("alignedReference", result.alignedSeq2());
+        return ResponseEntity.ok(resp);
+      } finally {
+        Files.deleteIfExists(qTemp);
+        Files.deleteIfExists(rTemp);
+      }
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(Map.of("error", "Alignment failed", "message", e.getMessage()));
     }
   }
 

--- a/src/main/java/DNAnalyzer/server/ApiController.java
+++ b/src/main/java/DNAnalyzer/server/ApiController.java
@@ -1,8 +1,8 @@
 package DNAnalyzer.server;
 
 import DNAnalyzer.core.DNAAnalysis;
-import DNAnalyzer.utils.core.DNATools;
 import DNAnalyzer.utils.alignment.SequenceAligner;
+import DNAnalyzer.utils.core.DNATools;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
@@ -98,7 +98,10 @@ public class ApiController {
           return ResponseEntity.badRequest()
               .body(
                   Map.of(
-                      "error", "Invalid sequence", "message", "Sequences contain invalid DNA characters"));
+                      "error",
+                      "Invalid sequence",
+                      "message",
+                      "Sequences contain invalid DNA characters"));
         }
 
         var result = SequenceAligner.align(qSeq, rSeq);

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -20,6 +20,7 @@ import DNAnalyzer.qc.QcStats;
 import DNAnalyzer.ui.gui.DNAnalyzerGUI;
 import DNAnalyzer.utils.core.DNATools;
 import DNAnalyzer.utils.core.Utils;
+import DNAnalyzer.utils.alignment.SequenceAligner;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
@@ -69,6 +70,11 @@ public class CmdArgs implements Runnable {
       names = {"--find"},
       description = "The DNA sequence to be found within the FASTA file.")
   File proteinFile;
+
+  @Option(
+      names = {"--align"},
+      description = "Reference FASTA file to align against the main DNA file.")
+  File alignFile;
 
   @Option(
       names = {"--reverse", "-r"},
@@ -140,6 +146,20 @@ public class CmdArgs implements Runnable {
       DNAnalyzerGUI.launchIt(args);
     } else {
       DNAAnalysis dnaAnalyzer = dnaAnalyzer(aminoAcid).isValidDna().replaceDNA("u", "t");
+
+      if (alignFile != null) {
+        try {
+          String reference = parseFile(alignFile);
+          String query = dnaAnalyzer.dna().getDna();
+          var result = DNAnalyzer.utils.alignment.SequenceAligner.align(query, reference);
+          System.out.println("Alignment score: " + result.score());
+          System.out.println(result.alignedSeq1());
+          System.out.println(result.alignedSeq2());
+        } catch (IOException e) {
+          System.err.println("Alignment failed: " + e.getMessage());
+        }
+        return;
+      }
 
       if (mutationCount > 0) {
         DNAMutation.generateAndWriteMutatedSequences(

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -20,7 +20,6 @@ import DNAnalyzer.qc.QcStats;
 import DNAnalyzer.ui.gui.DNAnalyzerGUI;
 import DNAnalyzer.utils.core.DNATools;
 import DNAnalyzer.utils.core.Utils;
-import DNAnalyzer.utils.alignment.SequenceAligner;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;

--- a/src/main/java/DNAnalyzer/utils/alignment/SequenceAligner.java
+++ b/src/main/java/DNAnalyzer/utils/alignment/SequenceAligner.java
@@ -1,0 +1,206 @@
+package DNAnalyzer.utils.alignment;
+
+/**
+ * Global alignment utilities using dynamic programming.
+ */
+public class SequenceAligner {
+
+    /** Result of an alignment. */
+    public record AlignmentResult(String alignedSeq1, String alignedSeq2, int score) {}
+
+    /**
+     * Align two sequences with default scoring parameters.
+     * @param seq1 first sequence
+     * @param seq2 second sequence
+     * @return alignment result
+     */
+    public static AlignmentResult align(String seq1, String seq2) {
+        return needlemanWunschAffine(seq1, seq2, 2, -1, -2, -1);
+    }
+
+    /**
+     * Needleman-Wunsch global alignment.
+     */
+    public static AlignmentResult needlemanWunsch(
+            String seq1, String seq2, int match, int mismatch, int gap) {
+        int m = seq1.length();
+        int n = seq2.length();
+        int[][] scores = new int[m + 1][n + 1];
+        Direction[][] traceback = new Direction[m + 1][n + 1];
+
+        for (int i = 0; i <= m; i++) {
+            scores[i][0] = i * gap;
+            traceback[i][0] = Direction.UP;
+        }
+        for (int j = 0; j <= n; j++) {
+            scores[0][j] = j * gap;
+            traceback[0][j] = Direction.LEFT;
+        }
+        traceback[0][0] = Direction.NONE;
+
+        for (int i = 1; i <= m; i++) {
+            for (int j = 1; j <= n; j++) {
+                int diag =
+                        scores[i - 1][j - 1]
+                                + (seq1.charAt(i - 1) == seq2.charAt(j - 1) ? match : mismatch);
+                int up = scores[i - 1][j] + gap;
+                int left = scores[i][j - 1] + gap;
+                int max = Math.max(diag, Math.max(up, left));
+                scores[i][j] = max;
+                if (max == diag) {
+                    traceback[i][j] = Direction.DIAGONAL;
+                } else if (max == up) {
+                    traceback[i][j] = Direction.UP;
+                } else {
+                    traceback[i][j] = Direction.LEFT;
+                }
+            }
+        }
+
+        StringBuilder a1 = new StringBuilder();
+        StringBuilder a2 = new StringBuilder();
+        int i = m;
+        int j = n;
+        while (i > 0 || j > 0) {
+            Direction dir = traceback[i][j];
+            if (dir == Direction.DIAGONAL) {
+                a1.append(seq1.charAt(i - 1));
+                a2.append(seq2.charAt(j - 1));
+                i--;
+                j--;
+            } else if (dir == Direction.UP) {
+                a1.append(seq1.charAt(i - 1));
+                a2.append('-');
+                i--;
+            } else if (dir == Direction.LEFT) {
+                a1.append('-');
+                a2.append(seq2.charAt(j - 1));
+                j--;
+            } else {
+                break;
+            }
+        }
+
+        return new AlignmentResult(a1.reverse().toString(), a2.reverse().toString(), scores[m][n]);
+    }
+
+    /**
+     * Needleman-Wunsch global alignment with affine gap penalties.
+     *
+     * @param seq1 first sequence
+     * @param seq2 second sequence
+     * @param match match score
+     * @param mismatch mismatch score
+     * @param gapOpen gap opening penalty (negative)
+     * @param gapExtend gap extension penalty (negative)
+     * @return alignment result
+     */
+    public static AlignmentResult needlemanWunschAffine(
+            String seq1,
+            String seq2,
+            int match,
+            int mismatch,
+            int gapOpen,
+            int gapExtend) {
+        int m = seq1.length();
+        int n = seq2.length();
+        int negInf = Integer.MIN_VALUE / 4;
+
+        int[][] main = new int[m + 1][n + 1];
+        int[][] gapRow = new int[m + 1][n + 1];
+        int[][] gapCol = new int[m + 1][n + 1];
+        DirectionState[][] trace = new DirectionState[m + 1][n + 1];
+
+        main[0][0] = 0;
+        gapRow[0][0] = negInf;
+        gapCol[0][0] = negInf;
+        trace[0][0] = DirectionState.DIAGONAL;
+
+        for (int i = 1; i <= m; i++) {
+            main[i][0] = negInf;
+            gapRow[i][0] = gapOpen + (i - 1) * gapExtend;
+            gapCol[i][0] = negInf;
+            trace[i][0] = DirectionState.UP;
+        }
+        for (int j = 1; j <= n; j++) {
+            main[0][j] = negInf;
+            gapRow[0][j] = negInf;
+            gapCol[0][j] = gapOpen + (j - 1) * gapExtend;
+            trace[0][j] = DirectionState.LEFT;
+        }
+
+        for (int i = 1; i <= m; i++) {
+            for (int j = 1; j <= n; j++) {
+                int scoreMatch =
+                        seq1.charAt(i - 1) == seq2.charAt(j - 1) ? match : mismatch;
+                int mDiag = Math.max(main[i - 1][j - 1], Math.max(gapRow[i - 1][j - 1], gapCol[i - 1][j - 1])) + scoreMatch;
+
+                int gRow = Math.max(main[i - 1][j] + gapOpen, gapRow[i - 1][j] + gapExtend);
+                int gCol = Math.max(main[i][j - 1] + gapOpen, gapCol[i][j - 1] + gapExtend);
+
+                main[i][j] = mDiag;
+                gapRow[i][j] = gRow;
+                gapCol[i][j] = gCol;
+
+                int max = Math.max(mDiag, Math.max(gRow, gCol));
+                if (max == mDiag) {
+                    trace[i][j] = DirectionState.DIAGONAL;
+                } else if (max == gRow) {
+                    trace[i][j] = DirectionState.UP;
+                } else {
+                    trace[i][j] = DirectionState.LEFT;
+                }
+            }
+        }
+
+        StringBuilder aligned1 = new StringBuilder();
+        StringBuilder aligned2 = new StringBuilder();
+
+        int i = m;
+        int j = n;
+        DirectionState state = trace[i][j];
+        int maxScore = Math.max(main[i][j], Math.max(gapRow[i][j], gapCol[i][j]));
+
+        while (i > 0 || j > 0) {
+            if (state == DirectionState.DIAGONAL) {
+                aligned1.append(seq1.charAt(i - 1));
+                aligned2.append(seq2.charAt(j - 1));
+                i--;
+                j--;
+                state = trace[i][j];
+            } else if (state == DirectionState.UP) {
+                aligned1.append(seq1.charAt(i - 1));
+                aligned2.append('-');
+                i--;
+                if (Math.max(main[i][j] + gapOpen, gapRow[i][j] + gapExtend) == main[i][j] + gapOpen) {
+                    state = trace[i][j];
+                }
+            } else if (state == DirectionState.LEFT) {
+                aligned1.append('-');
+                aligned2.append(seq2.charAt(j - 1));
+                j--;
+                if (Math.max(main[i][j] + gapOpen, gapCol[i][j] + gapExtend) == main[i][j] + gapOpen) {
+                    state = trace[i][j];
+                }
+            } else {
+                break;
+            }
+        }
+
+        return new AlignmentResult(
+                aligned1.reverse().toString(), aligned2.reverse().toString(), maxScore);
+    }
+
+    private enum DirectionState {
+        DIAGONAL,
+        UP,
+        LEFT
+    }
+
+    private enum Direction {
+        NONE,
+        DIAGONAL,
+        UP,
+        LEFT
+    }
+}

--- a/src/main/java/DNAnalyzer/utils/alignment/SequenceAligner.java
+++ b/src/main/java/DNAnalyzer/utils/alignment/SequenceAligner.java
@@ -1,206 +1,198 @@
 package DNAnalyzer.utils.alignment;
 
-/**
- * Global alignment utilities using dynamic programming.
- */
+/** Global alignment utilities using dynamic programming. */
 public class SequenceAligner {
 
-    /** Result of an alignment. */
-    public record AlignmentResult(String alignedSeq1, String alignedSeq2, int score) {}
+  /** Result of an alignment. */
+  public record AlignmentResult(String alignedSeq1, String alignedSeq2, int score) {}
 
-    /**
-     * Align two sequences with default scoring parameters.
-     * @param seq1 first sequence
-     * @param seq2 second sequence
-     * @return alignment result
-     */
-    public static AlignmentResult align(String seq1, String seq2) {
-        return needlemanWunschAffine(seq1, seq2, 2, -1, -2, -1);
+  /**
+   * Align two sequences with default scoring parameters.
+   *
+   * @param seq1 first sequence
+   * @param seq2 second sequence
+   * @return alignment result
+   */
+  public static AlignmentResult align(String seq1, String seq2) {
+    return needlemanWunschAffine(seq1, seq2, 2, -1, -2, -1);
+  }
+
+  /** Needleman-Wunsch global alignment. */
+  public static AlignmentResult needlemanWunsch(
+      String seq1, String seq2, int match, int mismatch, int gap) {
+    int m = seq1.length();
+    int n = seq2.length();
+    int[][] scores = new int[m + 1][n + 1];
+    Direction[][] traceback = new Direction[m + 1][n + 1];
+
+    for (int i = 0; i <= m; i++) {
+      scores[i][0] = i * gap;
+      traceback[i][0] = Direction.UP;
+    }
+    for (int j = 0; j <= n; j++) {
+      scores[0][j] = j * gap;
+      traceback[0][j] = Direction.LEFT;
+    }
+    traceback[0][0] = Direction.NONE;
+
+    for (int i = 1; i <= m; i++) {
+      for (int j = 1; j <= n; j++) {
+        int diag =
+            scores[i - 1][j - 1] + (seq1.charAt(i - 1) == seq2.charAt(j - 1) ? match : mismatch);
+        int up = scores[i - 1][j] + gap;
+        int left = scores[i][j - 1] + gap;
+        int max = Math.max(diag, Math.max(up, left));
+        scores[i][j] = max;
+        if (max == diag) {
+          traceback[i][j] = Direction.DIAGONAL;
+        } else if (max == up) {
+          traceback[i][j] = Direction.UP;
+        } else {
+          traceback[i][j] = Direction.LEFT;
+        }
+      }
     }
 
-    /**
-     * Needleman-Wunsch global alignment.
-     */
-    public static AlignmentResult needlemanWunsch(
-            String seq1, String seq2, int match, int mismatch, int gap) {
-        int m = seq1.length();
-        int n = seq2.length();
-        int[][] scores = new int[m + 1][n + 1];
-        Direction[][] traceback = new Direction[m + 1][n + 1];
-
-        for (int i = 0; i <= m; i++) {
-            scores[i][0] = i * gap;
-            traceback[i][0] = Direction.UP;
-        }
-        for (int j = 0; j <= n; j++) {
-            scores[0][j] = j * gap;
-            traceback[0][j] = Direction.LEFT;
-        }
-        traceback[0][0] = Direction.NONE;
-
-        for (int i = 1; i <= m; i++) {
-            for (int j = 1; j <= n; j++) {
-                int diag =
-                        scores[i - 1][j - 1]
-                                + (seq1.charAt(i - 1) == seq2.charAt(j - 1) ? match : mismatch);
-                int up = scores[i - 1][j] + gap;
-                int left = scores[i][j - 1] + gap;
-                int max = Math.max(diag, Math.max(up, left));
-                scores[i][j] = max;
-                if (max == diag) {
-                    traceback[i][j] = Direction.DIAGONAL;
-                } else if (max == up) {
-                    traceback[i][j] = Direction.UP;
-                } else {
-                    traceback[i][j] = Direction.LEFT;
-                }
-            }
-        }
-
-        StringBuilder a1 = new StringBuilder();
-        StringBuilder a2 = new StringBuilder();
-        int i = m;
-        int j = n;
-        while (i > 0 || j > 0) {
-            Direction dir = traceback[i][j];
-            if (dir == Direction.DIAGONAL) {
-                a1.append(seq1.charAt(i - 1));
-                a2.append(seq2.charAt(j - 1));
-                i--;
-                j--;
-            } else if (dir == Direction.UP) {
-                a1.append(seq1.charAt(i - 1));
-                a2.append('-');
-                i--;
-            } else if (dir == Direction.LEFT) {
-                a1.append('-');
-                a2.append(seq2.charAt(j - 1));
-                j--;
-            } else {
-                break;
-            }
-        }
-
-        return new AlignmentResult(a1.reverse().toString(), a2.reverse().toString(), scores[m][n]);
+    StringBuilder a1 = new StringBuilder();
+    StringBuilder a2 = new StringBuilder();
+    int i = m;
+    int j = n;
+    while (i > 0 || j > 0) {
+      Direction dir = traceback[i][j];
+      if (dir == Direction.DIAGONAL) {
+        a1.append(seq1.charAt(i - 1));
+        a2.append(seq2.charAt(j - 1));
+        i--;
+        j--;
+      } else if (dir == Direction.UP) {
+        a1.append(seq1.charAt(i - 1));
+        a2.append('-');
+        i--;
+      } else if (dir == Direction.LEFT) {
+        a1.append('-');
+        a2.append(seq2.charAt(j - 1));
+        j--;
+      } else {
+        break;
+      }
     }
 
-    /**
-     * Needleman-Wunsch global alignment with affine gap penalties.
-     *
-     * @param seq1 first sequence
-     * @param seq2 second sequence
-     * @param match match score
-     * @param mismatch mismatch score
-     * @param gapOpen gap opening penalty (negative)
-     * @param gapExtend gap extension penalty (negative)
-     * @return alignment result
-     */
-    public static AlignmentResult needlemanWunschAffine(
-            String seq1,
-            String seq2,
-            int match,
-            int mismatch,
-            int gapOpen,
-            int gapExtend) {
-        int m = seq1.length();
-        int n = seq2.length();
-        int negInf = Integer.MIN_VALUE / 4;
+    return new AlignmentResult(a1.reverse().toString(), a2.reverse().toString(), scores[m][n]);
+  }
 
-        int[][] main = new int[m + 1][n + 1];
-        int[][] gapRow = new int[m + 1][n + 1];
-        int[][] gapCol = new int[m + 1][n + 1];
-        DirectionState[][] trace = new DirectionState[m + 1][n + 1];
+  /**
+   * Needleman-Wunsch global alignment with affine gap penalties.
+   *
+   * @param seq1 first sequence
+   * @param seq2 second sequence
+   * @param match match score
+   * @param mismatch mismatch score
+   * @param gapOpen gap opening penalty (negative)
+   * @param gapExtend gap extension penalty (negative)
+   * @return alignment result
+   */
+  public static AlignmentResult needlemanWunschAffine(
+      String seq1, String seq2, int match, int mismatch, int gapOpen, int gapExtend) {
+    int m = seq1.length();
+    int n = seq2.length();
+    int negInf = Integer.MIN_VALUE / 4;
 
-        main[0][0] = 0;
-        gapRow[0][0] = negInf;
-        gapCol[0][0] = negInf;
-        trace[0][0] = DirectionState.DIAGONAL;
+    int[][] main = new int[m + 1][n + 1];
+    int[][] gapRow = new int[m + 1][n + 1];
+    int[][] gapCol = new int[m + 1][n + 1];
+    DirectionState[][] trace = new DirectionState[m + 1][n + 1];
 
-        for (int i = 1; i <= m; i++) {
-            main[i][0] = negInf;
-            gapRow[i][0] = gapOpen + (i - 1) * gapExtend;
-            gapCol[i][0] = negInf;
-            trace[i][0] = DirectionState.UP;
-        }
-        for (int j = 1; j <= n; j++) {
-            main[0][j] = negInf;
-            gapRow[0][j] = negInf;
-            gapCol[0][j] = gapOpen + (j - 1) * gapExtend;
-            trace[0][j] = DirectionState.LEFT;
-        }
+    main[0][0] = 0;
+    gapRow[0][0] = negInf;
+    gapCol[0][0] = negInf;
+    trace[0][0] = DirectionState.DIAGONAL;
 
-        for (int i = 1; i <= m; i++) {
-            for (int j = 1; j <= n; j++) {
-                int scoreMatch =
-                        seq1.charAt(i - 1) == seq2.charAt(j - 1) ? match : mismatch;
-                int mDiag = Math.max(main[i - 1][j - 1], Math.max(gapRow[i - 1][j - 1], gapCol[i - 1][j - 1])) + scoreMatch;
-
-                int gRow = Math.max(main[i - 1][j] + gapOpen, gapRow[i - 1][j] + gapExtend);
-                int gCol = Math.max(main[i][j - 1] + gapOpen, gapCol[i][j - 1] + gapExtend);
-
-                main[i][j] = mDiag;
-                gapRow[i][j] = gRow;
-                gapCol[i][j] = gCol;
-
-                int max = Math.max(mDiag, Math.max(gRow, gCol));
-                if (max == mDiag) {
-                    trace[i][j] = DirectionState.DIAGONAL;
-                } else if (max == gRow) {
-                    trace[i][j] = DirectionState.UP;
-                } else {
-                    trace[i][j] = DirectionState.LEFT;
-                }
-            }
-        }
-
-        StringBuilder aligned1 = new StringBuilder();
-        StringBuilder aligned2 = new StringBuilder();
-
-        int i = m;
-        int j = n;
-        DirectionState state = trace[i][j];
-        int maxScore = Math.max(main[i][j], Math.max(gapRow[i][j], gapCol[i][j]));
-
-        while (i > 0 || j > 0) {
-            if (state == DirectionState.DIAGONAL) {
-                aligned1.append(seq1.charAt(i - 1));
-                aligned2.append(seq2.charAt(j - 1));
-                i--;
-                j--;
-                state = trace[i][j];
-            } else if (state == DirectionState.UP) {
-                aligned1.append(seq1.charAt(i - 1));
-                aligned2.append('-');
-                i--;
-                if (Math.max(main[i][j] + gapOpen, gapRow[i][j] + gapExtend) == main[i][j] + gapOpen) {
-                    state = trace[i][j];
-                }
-            } else if (state == DirectionState.LEFT) {
-                aligned1.append('-');
-                aligned2.append(seq2.charAt(j - 1));
-                j--;
-                if (Math.max(main[i][j] + gapOpen, gapCol[i][j] + gapExtend) == main[i][j] + gapOpen) {
-                    state = trace[i][j];
-                }
-            } else {
-                break;
-            }
-        }
-
-        return new AlignmentResult(
-                aligned1.reverse().toString(), aligned2.reverse().toString(), maxScore);
+    for (int i = 1; i <= m; i++) {
+      main[i][0] = negInf;
+      gapRow[i][0] = gapOpen + (i - 1) * gapExtend;
+      gapCol[i][0] = negInf;
+      trace[i][0] = DirectionState.UP;
+    }
+    for (int j = 1; j <= n; j++) {
+      main[0][j] = negInf;
+      gapRow[0][j] = negInf;
+      gapCol[0][j] = gapOpen + (j - 1) * gapExtend;
+      trace[0][j] = DirectionState.LEFT;
     }
 
-    private enum DirectionState {
-        DIAGONAL,
-        UP,
-        LEFT
+    for (int i = 1; i <= m; i++) {
+      for (int j = 1; j <= n; j++) {
+        int scoreMatch = seq1.charAt(i - 1) == seq2.charAt(j - 1) ? match : mismatch;
+        int mDiag =
+            Math.max(main[i - 1][j - 1], Math.max(gapRow[i - 1][j - 1], gapCol[i - 1][j - 1]))
+                + scoreMatch;
+
+        int gRow = Math.max(main[i - 1][j] + gapOpen, gapRow[i - 1][j] + gapExtend);
+        int gCol = Math.max(main[i][j - 1] + gapOpen, gapCol[i][j - 1] + gapExtend);
+
+        main[i][j] = mDiag;
+        gapRow[i][j] = gRow;
+        gapCol[i][j] = gCol;
+
+        int max = Math.max(mDiag, Math.max(gRow, gCol));
+        if (max == mDiag) {
+          trace[i][j] = DirectionState.DIAGONAL;
+        } else if (max == gRow) {
+          trace[i][j] = DirectionState.UP;
+        } else {
+          trace[i][j] = DirectionState.LEFT;
+        }
+      }
     }
 
-    private enum Direction {
-        NONE,
-        DIAGONAL,
-        UP,
-        LEFT
+    StringBuilder aligned1 = new StringBuilder();
+    StringBuilder aligned2 = new StringBuilder();
+
+    int i = m;
+    int j = n;
+    DirectionState state = trace[i][j];
+    int maxScore = Math.max(main[i][j], Math.max(gapRow[i][j], gapCol[i][j]));
+
+    while (i > 0 || j > 0) {
+      if (state == DirectionState.DIAGONAL) {
+        aligned1.append(seq1.charAt(i - 1));
+        aligned2.append(seq2.charAt(j - 1));
+        i--;
+        j--;
+        state = trace[i][j];
+      } else if (state == DirectionState.UP) {
+        aligned1.append(seq1.charAt(i - 1));
+        aligned2.append('-');
+        i--;
+        if (Math.max(main[i][j] + gapOpen, gapRow[i][j] + gapExtend) == main[i][j] + gapOpen) {
+          state = trace[i][j];
+        }
+      } else if (state == DirectionState.LEFT) {
+        aligned1.append('-');
+        aligned2.append(seq2.charAt(j - 1));
+        j--;
+        if (Math.max(main[i][j] + gapOpen, gapCol[i][j] + gapExtend) == main[i][j] + gapOpen) {
+          state = trace[i][j];
+        }
+      } else {
+        break;
+      }
     }
+
+    return new AlignmentResult(
+        aligned1.reverse().toString(), aligned2.reverse().toString(), maxScore);
+  }
+
+  private enum DirectionState {
+    DIAGONAL,
+    UP,
+    LEFT
+  }
+
+  private enum Direction {
+    NONE,
+    DIAGONAL,
+    UP,
+    LEFT
+  }
 }

--- a/src/test/java/DNAnalyzer/utils/alignment/SequenceAlignerTest.java
+++ b/src/test/java/DNAnalyzer/utils/alignment/SequenceAlignerTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test;
 
 public class SequenceAlignerTest {
 
-    @Test
-    void simpleAlignment() {
-        SequenceAligner.AlignmentResult res = SequenceAligner.align("ACGT", "ACCT");
-        assertEquals(5, res.score());
-        assertEquals("ACGT", res.alignedSeq1());
-        assertEquals("ACCT", res.alignedSeq2());
-    }
+  @Test
+  void simpleAlignment() {
+    SequenceAligner.AlignmentResult res = SequenceAligner.align("ACGT", "ACCT");
+    assertEquals(5, res.score());
+    assertEquals("ACGT", res.alignedSeq1());
+    assertEquals("ACCT", res.alignedSeq2());
+  }
 }

--- a/src/test/java/DNAnalyzer/utils/alignment/SequenceAlignerTest.java
+++ b/src/test/java/DNAnalyzer/utils/alignment/SequenceAlignerTest.java
@@ -1,0 +1,16 @@
+package DNAnalyzer.utils.alignment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SequenceAlignerTest {
+
+    @Test
+    void simpleAlignment() {
+        SequenceAligner.AlignmentResult res = SequenceAligner.align("ACGT", "ACCT");
+        assertEquals(5, res.score());
+        assertEquals("ACGT", res.alignedSeq1());
+        assertEquals("ACCT", res.alignedSeq2());
+    }
+}


### PR DESCRIPTION
## Summary
- implement a Needleman–Wunsch aligner with affine gap penalties
- keep simple constant-gap aligner as a helper
- update unit test for new scoring

## Testing
- `./gradlew test` *(fails: could not download gradle-8.6-bin.zip due to no route to host)*