### PR TITLE
Add reproducible dev environment docs and container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install Java 17 and Python
+RUN apt-get update \
+    && apt-get install -y openjdk-17-jdk python3 python3-pip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH="$JAVA_HOME/bin:$PATH"
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,13 @@
 {
-  "tasks": {
-    "build": "./gradlew build"
+  "name": "DNAnalyzer DevContainer",
+  "dockerFile": "Dockerfile",
+  "forwardPorts": [8080],
+  "postCreateCommand": "./scripts/run-tests.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "java.home": "/usr/lib/jvm/java-17-openjdk-amd64"
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ We welcome contributions across experience levels:
 
 - [Guidelines for Contribution](./docs/contributing/Contribution_Guidelines.md)
 - [Git Usage Instructions](./docs/contributing/CONTRIBUTING.md)
+- [Development Environment](./docs/Development_Environment.md)
 
 <div align="center">
   <a href="https://github.com/VerisimilitudeX/DNAnalyzer/stargazers">

--- a/docs/Development_Environment.md
+++ b/docs/Development_Environment.md
@@ -1,0 +1,32 @@
+# Reproducible Development Environment
+
+This repository provides a container-based setup so you can develop and test DNAnalyzer consistently across local and cloud machines.
+
+## Requirements
+- Docker 20+
+- Git
+
+## Building the Container
+
+From the repository root run:
+```bash
+docker build -f .devcontainer/Dockerfile -t dnanalyzer-dev .
+```
+
+Start an interactive shell with:
+```bash
+docker run --rm -it -p 8080:8080 -v $(pwd):/workspace dnanalyzer-dev
+```
+
+The container executes `./scripts/run-tests.sh` after creation to verify the toolchain.
+
+## Codespaces
+
+GitHub Codespaces automatically uses the `.devcontainer` folder. After opening a codespace, tests run and you can start coding immediately.
+
+## Deployment Hooks
+
+- `gradle-publish.yml` publishes artifacts on release.
+- `static.yml` deploys the `web/` directory to GitHub Pages when changes are pushed to `main`.
+
+Modify these workflows if you add new deployment targets.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Java tests
+./gradlew test
+
+# Run Python tests if any are present
+if find . -path '*test*' -name '*.py' | grep -q .; then
+    python3 -m unittest discover -s . -p '*test*.py'
+fi


### PR DESCRIPTION
## Summary
- add dev container Dockerfile with Java and Python toolchains
- run tests automatically via `scripts/run-tests.sh`
- document container usage in `Development_Environment.md`
- link new doc from README

## Testing
- `./gradlew test` *(fails: No route to host)*