### PR TITLE
Add session packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ java -jar dnanalyzer.jar --align reference.fa --sw-align
 See [GPU_Smith_Waterman.md](docs/developer/GPU_Smith_Waterman.md) for further
 details.
 
+### Packaging Analysis Sessions
+
+After running DNAnalyzer you can archive the inputs, logs, and an interactive
+HTML report using `package-session.sh`:
+
+```bash
+./scripts/package-session.sh sample.fa
+```
+
+This creates a time-stamped ZIP file containing the FASTA file, console log,
+generated report, and any QC chart.
+
 ## Polygenic Health-Risk Scores
 
 DNAnalyzer now includes a lightweight polygenic risk score calculator. Supply a CSV file of SNP weights

--- a/docs/usage/package-session.md
+++ b/docs/usage/package-session.md
@@ -1,0 +1,16 @@
+# Packaging Analysis Sessions
+
+`package-session.sh` automates archiving a DNAnalyzer run. It executes the CLI, generates an interactive HTML report, and bundles the inputs and logs into a ZIP file.
+
+```bash
+./scripts/package-session.sh sample.fa
+```
+
+The script creates a `session_YYYYMMDD_HHMMSS.zip` archive containing:
+
+- The original FASTA file
+- `analysis.log` with the console output
+- `report.html` showing nucleotide counts and GC content
+- Any QC chart generated in `assets/reports`
+
+Pass any additional DNAnalyzer CLI arguments after the FASTA file to customize the run.

--- a/scripts/package-session.sh
+++ b/scripts/package-session.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <fasta_file> [DNAnalyzer options]" >&2
+  exit 1
+fi
+
+INPUT="$1"
+shift || true
+
+SESSION_DIR="session_$(date +%Y%m%d_%H%M%S)"
+mkdir "$SESSION_DIR"
+LOG_FILE="$SESSION_DIR/analysis.log"
+REPORT_FILE="$SESSION_DIR/report.html"
+
+# Run DNAnalyzer CLI and capture output
+java -jar lib/DNAnalyzer.jar "$INPUT" "$@" --detailed > "$LOG_FILE" 2>&1
+
+# Generate HTML report using existing utilities
+cat > "$SESSION_DIR/GenerateReport.java" <<'JAVA'
+import DNAnalyzer.report.AnalysisResult;
+import DNAnalyzer.report.ReportGenerator;
+import DNAnalyzer.utils.core.BasePairCounter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class GenerateReport {
+  public static void main(String[] args) throws Exception {
+    String dna = new String(Files.readAllBytes(Paths.get(args[0])));
+    BasePairCounter counter = new BasePairCounter(dna);
+    counter.countAdenine().countThymine().countGuanine().countCytosine().countUnknown();
+    long[] counts = counter.getCounts();
+    ReportGenerator.generateReport(
+        new AnalysisResult(counts[0], counts[1], counts[2], counts[3], counts[4]),
+        Paths.get(args[1]));
+  }
+}
+JAVA
+
+javac -cp lib/DNAnalyzer.jar "$SESSION_DIR/GenerateReport.java"
+java -cp lib/DNAnalyzer.jar:"$SESSION_DIR" GenerateReport "$INPUT" "$REPORT_FILE"
+
+# Copy input and any QC chart
+cp "$INPUT" "$SESSION_DIR/"
+if [ -f "assets/reports/$(basename "$INPUT")_qc.png" ]; then
+  cp "assets/reports/$(basename "$INPUT")_qc.png" "$SESSION_DIR/"
+fi
+
+zip -r "${SESSION_DIR}.zip" "$SESSION_DIR" >/dev/null
+printf '\nSession packaged at %s.zip\n' "$SESSION_DIR"


### PR DESCRIPTION
## Summary
- archive DNAnalyzer runs with `package-session.sh`
- document session packaging in new usage guide
- mention session packaging in README

## Testing
- `./scripts/run-tests.sh` *(fails: cannot find Java installation matching requirements)*

------
https://chatgpt.com/codex/tasks/task_e_684502a04b008332a097b039ce39be46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a script to automate packaging of analysis sessions, including input files, logs, reports, and quality control charts into a timestamped ZIP archive.

- **Documentation**
  - Added a new section to the README and a dedicated usage guide explaining how to use the session packaging script and detailing the contents of the archived output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->