### PR TITLE
Add ORF teaching mode

### DIFF
--- a/docs/usage/MetCLI.md
+++ b/docs/usage/MetCLI.md
@@ -27,4 +27,5 @@ A program to analyze DNA sequences.
       --min=<minCount>       The minimum count of the reading frame.
   -r, --reverse              Reverse the DNA sequence before processing.
   -V, --version              Print version information and exit.
+      --orfs                 Display open reading frames with translations.
   ```

--- a/src/main/java/DNAnalyzer/adapter/ApiKeyController.java
+++ b/src/main/java/DNAnalyzer/adapter/ApiKeyController.java
@@ -2,6 +2,8 @@ package DNAnalyzer.adapter;
 
 import DNAnalyzer.core.ApiKeyService;
 import DNAnalyzer.utils.ai.AIProvider;
+import DNAnalyzer.adapter.ApiKeyResponse;
+import DNAnalyzer.adapter.SetApiKeyRequest;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -51,38 +53,5 @@ public class ApiKeyController {
     } catch (IllegalArgumentException e) {
       return ResponseEntity.badRequest().body(Map.of("status", "error", "message", e.getMessage()));
     }
-  }
-}
-
-class ApiKeyResponse {
-  private boolean configured;
-
-  ApiKeyResponse(boolean configured) {
-    this.configured = configured;
-  }
-
-  public boolean isConfigured() {
-    return configured;
-  }
-}
-
-class SetApiKeyRequest {
-  private String apiKey;
-  private String provider;
-
-  public String getApiKey() {
-    return apiKey;
-  }
-
-  public void setApiKey(String apiKey) {
-    this.apiKey = apiKey;
-  }
-
-  public String getProvider() {
-    return provider;
-  }
-
-  public void setProvider(String provider) {
-    this.provider = provider;
   }
 }

--- a/src/main/java/DNAnalyzer/adapter/ApiKeyController.java
+++ b/src/main/java/DNAnalyzer/adapter/ApiKeyController.java
@@ -2,8 +2,6 @@ package DNAnalyzer.adapter;
 
 import DNAnalyzer.core.ApiKeyService;
 import DNAnalyzer.utils.ai.AIProvider;
-import DNAnalyzer.adapter.ApiKeyResponse;
-import DNAnalyzer.adapter.SetApiKeyRequest;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/DNAnalyzer/adapter/SetApiKeyRequest.java
+++ b/src/main/java/DNAnalyzer/adapter/SetApiKeyRequest.java
@@ -3,6 +3,7 @@ package DNAnalyzer.adapter;
 /** Request object for setting API key. */
 public class SetApiKeyRequest {
   private String apiKey;
+  private String provider;
 
   public String getApiKey() {
     return apiKey;
@@ -10,5 +11,13 @@ public class SetApiKeyRequest {
 
   public void setApiKey(String apiKey) {
     this.apiKey = apiKey;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
   }
 }

--- a/src/main/java/DNAnalyzer/core/readingframe/OpenReadingFrame.java
+++ b/src/main/java/DNAnalyzer/core/readingframe/OpenReadingFrame.java
@@ -1,5 +1,5 @@
 package DNAnalyzer.core.readingframe;
 
 /** Data class representing an open reading frame. */
-public record OpenReadingFrame(int start, int end, boolean forward, int frame,
-                               String sequence, String aminoAcids) {}
+public record OpenReadingFrame(
+    int start, int end, boolean forward, int frame, String sequence, String aminoAcids) {}

--- a/src/main/java/DNAnalyzer/core/readingframe/OpenReadingFrame.java
+++ b/src/main/java/DNAnalyzer/core/readingframe/OpenReadingFrame.java
@@ -1,0 +1,5 @@
+package DNAnalyzer.core.readingframe;
+
+/** Data class representing an open reading frame. */
+public record OpenReadingFrame(int start, int end, boolean forward, int frame,
+                               String sequence, String aminoAcids) {}

--- a/src/main/java/DNAnalyzer/core/readingframe/ReadingFrameAnalyzer.java
+++ b/src/main/java/DNAnalyzer/core/readingframe/ReadingFrameAnalyzer.java
@@ -1,235 +1,228 @@
 package DNAnalyzer.core.readingframe;
 
+import DNAnalyzer.utils.protein.CodonTranslator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-
-import DNAnalyzer.core.readingframe.OpenReadingFrame;
-import DNAnalyzer.core.readingframe.PotentialGene;
-import DNAnalyzer.core.readingframe.PoissonCalculator;
-import DNAnalyzer.utils.protein.CodonTranslator;
-
 import org.springframework.stereotype.Component;
 
 /**
- * Analyzes DNA sequences to identify potential reading frames and genes.
- * This class implements rigorous scientific methods for DNA sequence analysis,
- * including statistical validation and error checking.
- * 
- * References:
- * 1. Watson, J. D., et al. (2008). Molecular Biology of the Gene, 6th Edition
- * 2. Mount, D. W. (2004). Bioinformatics: Sequence and Genome Analysis
- * 
+ * Analyzes DNA sequences to identify potential reading frames and genes. This class implements
+ * rigorous scientific methods for DNA sequence analysis, including statistical validation and error
+ * checking.
+ *
+ * <p>References: 1. Watson, J. D., et al. (2008). Molecular Biology of the Gene, 6th Edition 2.
+ * Mount, D. W. (2004). Bioinformatics: Sequence and Genome Analysis
+ *
  * @version 2.0
  * @since 1.0
  */
 @Component
 public class ReadingFrameAnalyzer {
-    private static final Logger LOGGER = Logger.getLogger(ReadingFrameAnalyzer.class.getName());
-    
-    // Scientific constants
-    private static final double MIN_GC_CONTENT = 0.45; // 45% minimum GC content
-    private static final double MAX_GC_CONTENT = 0.60; // 60% maximum GC content
-    private static final int MIN_GENE_LENGTH = 300; // Minimum gene length in base pairs
-    private static final Pattern DNA_SEQUENCE_PATTERN = Pattern.compile("^[ATCG]+$");
+  private static final Logger LOGGER = Logger.getLogger(ReadingFrameAnalyzer.class.getName());
 
-    private final PoissonCalculator poissonCalculator;
+  // Scientific constants
+  private static final double MIN_GC_CONTENT = 0.45; // 45% minimum GC content
+  private static final double MAX_GC_CONTENT = 0.60; // 60% maximum GC content
+  private static final int MIN_GENE_LENGTH = 300; // Minimum gene length in base pairs
+  private static final Pattern DNA_SEQUENCE_PATTERN = Pattern.compile("^[ATCG]+$");
 
-    public ReadingFrameAnalyzer(PoissonCalculator poissonCalculator) {
-        this.poissonCalculator = poissonCalculator;
+  private final PoissonCalculator poissonCalculator;
+
+  public ReadingFrameAnalyzer(PoissonCalculator poissonCalculator) {
+    this.poissonCalculator = poissonCalculator;
+  }
+
+  /**
+   * Analyzes a DNA sequence to identify potential reading frames and genes. Implements rigorous
+   * validation and statistical analysis.
+   *
+   * @param sequence The DNA sequence to analyze
+   * @param minLength Minimum length for potential genes
+   * @return List of identified reading frames
+   * @throws IllegalArgumentException if sequence is invalid or parameters are out of range
+   */
+  public List<ReadingFrame> analyzeSequence(String sequence, int minLength) {
+    validateInputParameters(sequence, minLength);
+    LOGGER.info("Starting sequence analysis of length: " + sequence.length());
+
+    List<ReadingFrame> readingFrames = new ArrayList<>();
+
+    // Analyze in both forward and reverse directions
+    analyzeDirection(sequence, minLength, true, readingFrames);
+    analyzeDirection(sequence, minLength, false, readingFrames);
+
+    LOGGER.info("Found " + readingFrames.size() + " potential reading frames");
+    return readingFrames;
+  }
+
+  /**
+   * Find open reading frames and translate them to amino acid sequences.
+   *
+   * @param sequence DNA sequence to analyze
+   * @param minLength Minimum ORF length
+   * @return List of open reading frames
+   */
+  public List<OpenReadingFrame> findOpenReadingFrames(String sequence, int minLength) {
+    validateInputParameters(sequence, Math.max(minLength, MIN_GENE_LENGTH));
+    List<OpenReadingFrame> orfs = new ArrayList<>();
+    findOrfsDirection(sequence, minLength, true, orfs);
+    findOrfsDirection(sequence, minLength, false, orfs);
+    return orfs;
+  }
+
+  private void findOrfsDirection(
+      String sequence, int minLength, boolean forward, List<OpenReadingFrame> orfs) {
+    String working = forward ? sequence : reverseComplement(sequence);
+    for (int frame = 0; frame < 3; frame++) {
+      List<PotentialGene> genes = findPotentialGenes(working, frame, minLength);
+      for (PotentialGene gene : genes) {
+        String orfSeq = working.substring(gene.getStartPosition(), gene.getEndPosition());
+        String aaSeq = CodonTranslator.translate(orfSeq);
+        orfs.add(
+            new OpenReadingFrame(
+                gene.getStartPosition(), gene.getEndPosition(), forward, frame, orfSeq, aaSeq));
+      }
+    }
+  }
+
+  /**
+   * Validates input parameters against scientific criteria.
+   *
+   * @param sequence DNA sequence to validate
+   * @param minLength Minimum length parameter to validate
+   * @throws IllegalArgumentException if parameters don't meet criteria
+   */
+  private void validateInputParameters(String sequence, int minLength) {
+    if (sequence == null || sequence.isEmpty()) {
+      throw new IllegalArgumentException("DNA sequence cannot be null or empty");
     }
 
-    /**
-     * Analyzes a DNA sequence to identify potential reading frames and genes.
-     * Implements rigorous validation and statistical analysis.
-     *
-     * @param sequence The DNA sequence to analyze
-     * @param minLength Minimum length for potential genes
-     * @return List of identified reading frames
-     * @throws IllegalArgumentException if sequence is invalid or parameters are out of range
-     */
-    public List<ReadingFrame> analyzeSequence(String sequence, int minLength) {
-        validateInputParameters(sequence, minLength);
-        LOGGER.info("Starting sequence analysis of length: " + sequence.length());
-
-        List<ReadingFrame> readingFrames = new ArrayList<>();
-        
-        // Analyze in both forward and reverse directions
-        analyzeDirection(sequence, minLength, true, readingFrames);
-        analyzeDirection(sequence, minLength, false, readingFrames);
-
-        LOGGER.info("Found " + readingFrames.size() + " potential reading frames");
-        return readingFrames;
+    if (!DNA_SEQUENCE_PATTERN.matcher(sequence).matches()) {
+      throw new IllegalArgumentException("Invalid DNA sequence: must contain only A, T, C, G");
     }
 
-    /**
-     * Find open reading frames and translate them to amino acid sequences.
-     *
-     * @param sequence DNA sequence to analyze
-     * @param minLength Minimum ORF length
-     * @return List of open reading frames
-     */
-    public List<OpenReadingFrame> findOpenReadingFrames(String sequence, int minLength) {
-        validateInputParameters(sequence, Math.max(minLength, MIN_GENE_LENGTH));
-        List<OpenReadingFrame> orfs = new ArrayList<>();
-        findOrfsDirection(sequence, minLength, true, orfs);
-        findOrfsDirection(sequence, minLength, false, orfs);
-        return orfs;
+    if (minLength < MIN_GENE_LENGTH) {
+      throw new IllegalArgumentException(
+          "Minimum length must be at least " + MIN_GENE_LENGTH + " base pairs");
     }
 
-    private void findOrfsDirection(String sequence, int minLength, boolean forward,
-                                   List<OpenReadingFrame> orfs) {
-        String working = forward ? sequence : reverseComplement(sequence);
-        for (int frame = 0; frame < 3; frame++) {
-            List<PotentialGene> genes = findPotentialGenes(working, frame, minLength);
-            for (PotentialGene gene : genes) {
-                String orfSeq = working.substring(gene.getStartPosition(), gene.getEndPosition());
-                String aaSeq = CodonTranslator.translate(orfSeq);
-                orfs.add(new OpenReadingFrame(gene.getStartPosition(), gene.getEndPosition(),
-                        forward, frame, orfSeq, aaSeq));
-            }
+    double gcContent = calculateGCContent(sequence);
+    if (gcContent < MIN_GC_CONTENT || gcContent > MAX_GC_CONTENT) {
+      LOGGER.warning("GC content (" + gcContent + ") is outside optimal range");
+    }
+  }
+
+  /**
+   * Calculates GC content of a DNA sequence.
+   *
+   * @param sequence DNA sequence
+   * @return GC content as a ratio
+   */
+  private double calculateGCContent(String sequence) {
+    long gcCount = sequence.chars().filter(ch -> ch == 'G' || ch == 'C').count();
+    return (double) gcCount / sequence.length();
+  }
+
+  /**
+   * Analyzes sequence in a specific direction to identify reading frames.
+   *
+   * @param sequence DNA sequence
+   * @param minLength Minimum length criteria
+   * @param forward Direction of analysis
+   * @param readingFrames List to store found reading frames
+   */
+  private void analyzeDirection(
+      String sequence, int minLength, boolean forward, List<ReadingFrame> readingFrames) {
+    String workingSequence = forward ? sequence : reverseComplement(sequence);
+
+    for (int frame = 0; frame < 3; frame++) {
+      List<PotentialGene> genes = findPotentialGenes(workingSequence, frame, minLength);
+      if (!genes.isEmpty()) {
+        ReadingFrame readingFrame = new ReadingFrame(frame, forward, genes);
+        readingFrames.add(readingFrame);
+      }
+    }
+  }
+
+  /**
+   * Finds potential genes in a given reading frame.
+   *
+   * @param sequence DNA sequence
+   * @param frame Reading frame offset
+   * @param minLength Minimum gene length
+   * @return List of potential genes
+   */
+  private List<PotentialGene> findPotentialGenes(String sequence, int frame, int minLength) {
+    List<PotentialGene> genes = new ArrayList<>();
+    int start = frame;
+
+    while (start + 2 < sequence.length()) {
+      if (isStartCodon(sequence.substring(start, start + 3))) {
+        int end = findStopCodon(sequence, start + 3);
+        if (end != -1 && (end - start) >= minLength) {
+          double significance = poissonCalculator.calculateSignificance(end - start);
+          if (significance > 0.95) { // 95% confidence threshold
+            genes.add(new PotentialGene(start, end, significance));
+          }
         }
+      }
+      start += 3;
     }
 
-    /**
-     * Validates input parameters against scientific criteria.
-     * 
-     * @param sequence DNA sequence to validate
-     * @param minLength Minimum length parameter to validate
-     * @throws IllegalArgumentException if parameters don't meet criteria
-     */
-    private void validateInputParameters(String sequence, int minLength) {
-        if (sequence == null || sequence.isEmpty()) {
-            throw new IllegalArgumentException("DNA sequence cannot be null or empty");
-        }
-        
-        if (!DNA_SEQUENCE_PATTERN.matcher(sequence).matches()) {
-            throw new IllegalArgumentException("Invalid DNA sequence: must contain only A, T, C, G");
-        }
-        
-        if (minLength < MIN_GENE_LENGTH) {
-            throw new IllegalArgumentException(
-                "Minimum length must be at least " + MIN_GENE_LENGTH + " base pairs"
-            );
-        }
+    return genes;
+  }
 
-        double gcContent = calculateGCContent(sequence);
-        if (gcContent < MIN_GC_CONTENT || gcContent > MAX_GC_CONTENT) {
-            LOGGER.warning("GC content (" + gcContent + ") is outside optimal range");
-        }
-    }
+  /** Checks if a codon is a start codon (ATG). */
+  private boolean isStartCodon(String codon) {
+    return codon.equals("ATG");
+  }
 
-    /**
-     * Calculates GC content of a DNA sequence.
-     * 
-     * @param sequence DNA sequence
-     * @return GC content as a ratio
-     */
-    private double calculateGCContent(String sequence) {
-        long gcCount = sequence.chars()
-            .filter(ch -> ch == 'G' || ch == 'C')
-            .count();
-        return (double) gcCount / sequence.length();
+  /**
+   * Finds the next stop codon in the sequence.
+   *
+   * @param sequence DNA sequence
+   * @param start Starting position
+   * @return Position of stop codon or -1 if not found
+   */
+  private int findStopCodon(String sequence, int start) {
+    for (int i = start; i < sequence.length() - 2; i += 3) {
+      String codon = sequence.substring(i, i + 3);
+      if (codon.equals("TAA") || codon.equals("TAG") || codon.equals("TGA")) {
+        return i + 3;
+      }
     }
+    return -1;
+  }
 
-    /**
-     * Analyzes sequence in a specific direction to identify reading frames.
-     * 
-     * @param sequence DNA sequence
-     * @param minLength Minimum length criteria
-     * @param forward Direction of analysis
-     * @param readingFrames List to store found reading frames
-     */
-    private void analyzeDirection(String sequence, int minLength, boolean forward, 
-                                List<ReadingFrame> readingFrames) {
-        String workingSequence = forward ? sequence : reverseComplement(sequence);
-        
-        for (int frame = 0; frame < 3; frame++) {
-            List<PotentialGene> genes = findPotentialGenes(workingSequence, frame, minLength);
-            if (!genes.isEmpty()) {
-                ReadingFrame readingFrame = new ReadingFrame(frame, forward, genes);
-                readingFrames.add(readingFrame);
-            }
-        }
+  /**
+   * Generates the reverse complement of a DNA sequence.
+   *
+   * @param sequence DNA sequence
+   * @return Reverse complement sequence
+   */
+  private String reverseComplement(String sequence) {
+    StringBuilder complement = new StringBuilder();
+    for (int i = sequence.length() - 1; i >= 0; i--) {
+      complement.append(complementBase(sequence.charAt(i)));
     }
+    return complement.toString();
+  }
 
-    /**
-     * Finds potential genes in a given reading frame.
-     * 
-     * @param sequence DNA sequence
-     * @param frame Reading frame offset
-     * @param minLength Minimum gene length
-     * @return List of potential genes
-     */
-    private List<PotentialGene> findPotentialGenes(String sequence, int frame, int minLength) {
-        List<PotentialGene> genes = new ArrayList<>();
-        int start = frame;
-        
-        while (start + 2 < sequence.length()) {
-            if (isStartCodon(sequence.substring(start, start + 3))) {
-                int end = findStopCodon(sequence, start + 3);
-                if (end != -1 && (end - start) >= minLength) {
-                    double significance = poissonCalculator.calculateSignificance(end - start);
-                    if (significance > 0.95) { // 95% confidence threshold
-                        genes.add(new PotentialGene(start, end, significance));
-                    }
-                }
-            }
-            start += 3;
-        }
-        
-        return genes;
+  /** Returns the complement of a DNA base. */
+  private char complementBase(char base) {
+    switch (base) {
+      case 'A':
+        return 'T';
+      case 'T':
+        return 'A';
+      case 'C':
+        return 'G';
+      case 'G':
+        return 'C';
+      default:
+        throw new IllegalArgumentException("Invalid DNA base: " + base);
     }
-
-    /**
-     * Checks if a codon is a start codon (ATG).
-     */
-    private boolean isStartCodon(String codon) {
-        return codon.equals("ATG");
-    }
-
-    /**
-     * Finds the next stop codon in the sequence.
-     * 
-     * @param sequence DNA sequence
-     * @param start Starting position
-     * @return Position of stop codon or -1 if not found
-     */
-    private int findStopCodon(String sequence, int start) {
-        for (int i = start; i < sequence.length() - 2; i += 3) {
-            String codon = sequence.substring(i, i + 3);
-            if (codon.equals("TAA") || codon.equals("TAG") || codon.equals("TGA")) {
-                return i + 3;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * Generates the reverse complement of a DNA sequence.
-     * 
-     * @param sequence DNA sequence
-     * @return Reverse complement sequence
-     */
-    private String reverseComplement(String sequence) {
-        StringBuilder complement = new StringBuilder();
-        for (int i = sequence.length() - 1; i >= 0; i--) {
-            complement.append(complementBase(sequence.charAt(i)));
-        }
-        return complement.toString();
-    }
-
-    /**
-     * Returns the complement of a DNA base.
-     */
-    private char complementBase(char base) {
-        switch (base) {
-            case 'A': return 'T';
-            case 'T': return 'A';
-            case 'C': return 'G';
-            case 'G': return 'C';
-            default: throw new IllegalArgumentException("Invalid DNA base: " + base);
-        }
-    }
+  }
 }

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -266,9 +266,7 @@ public class CmdArgs implements Runnable {
         DNAnalyzer.core.readingframe.ReadingFrameAnalyzer rfAnalyzer =
             new DNAnalyzer.core.readingframe.ReadingFrameAnalyzer(
                 new DNAnalyzer.core.readingframe.PoissonCalculator());
-        var orfs =
-            rfAnalyzer.findOpenReadingFrames(
-                dnaAnalyzer.dna().getDna().toUpperCase(), 300);
+        var orfs = rfAnalyzer.findOpenReadingFrames(dnaAnalyzer.dna().getDna().toUpperCase(), 300);
         System.out.println("\nOpen Reading Frames:");
         for (var orf : orfs) {
           System.out.printf(

--- a/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
+++ b/src/main/java/DNAnalyzer/ui/cli/CmdArgs.java
@@ -149,6 +149,11 @@ public class CmdArgs implements Runnable {
       description = "CSV of SNP weights for polygenic risk scoring")
   File prsWeights;
 
+  @Option(
+      names = {"--orfs"},
+      description = "Display open reading frames with amino acid translation")
+  boolean showOrfs;
+
   /**
    * Output a list of proteins, GC content, Nucleotide content, and other information found in a DNA
    * sequence.
@@ -255,6 +260,26 @@ public class CmdArgs implements Runnable {
 
       if (enablePlugins) {
         new DNAnalyzer.plugin.PluginManager().runPlugins(dnaAnalyzer.dna(), System.out);
+      }
+
+      if (showOrfs) {
+        DNAnalyzer.core.readingframe.ReadingFrameAnalyzer rfAnalyzer =
+            new DNAnalyzer.core.readingframe.ReadingFrameAnalyzer(
+                new DNAnalyzer.core.readingframe.PoissonCalculator());
+        var orfs =
+            rfAnalyzer.findOpenReadingFrames(
+                dnaAnalyzer.dna().getDna().toUpperCase(), 300);
+        System.out.println("\nOpen Reading Frames:");
+        for (var orf : orfs) {
+          System.out.printf(
+              "Frame %d (%s) %d-%d: %s -> %s%n",
+              orf.frame(),
+              orf.forward() ? "forward" : "reverse",
+              orf.start(),
+              orf.end(),
+              orf.sequence(),
+              orf.aminoAcids());
+        }
       }
     }
   }

--- a/src/main/java/DNAnalyzer/utils/protein/CodonTranslator.java
+++ b/src/main/java/DNAnalyzer/utils/protein/CodonTranslator.java
@@ -1,0 +1,59 @@
+package DNAnalyzer.utils.protein;
+
+import DNAnalyzer.data.aminoAcid.AminoAcid;
+import DNAnalyzer.data.codon.CodonDataConstants;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Utility to translate DNA codons to amino acid single-letter codes. */
+public class CodonTranslator {
+    private static final Map<String, Character> CODON_MAP = new HashMap<>();
+    private static final Map<AminoAcid, Character> LETTER_MAP = Map.ofEntries(
+        Map.entry(AminoAcid.ALANINE, 'A'),
+        Map.entry(AminoAcid.CYSTEINE, 'C'),
+        Map.entry(AminoAcid.ASPARTIC_ACID, 'D'),
+        Map.entry(AminoAcid.GLUTAMIC_ACID, 'E'),
+        Map.entry(AminoAcid.PHENYLALANINE, 'F'),
+        Map.entry(AminoAcid.GLYCINE, 'G'),
+        Map.entry(AminoAcid.HISTIDINE, 'H'),
+        Map.entry(AminoAcid.ISOLEUCINE, 'I'),
+        Map.entry(AminoAcid.LYSINE, 'K'),
+        Map.entry(AminoAcid.LEUCINE, 'L'),
+        Map.entry(AminoAcid.METHIONINE, 'M'),
+        Map.entry(AminoAcid.ASPARAGINE, 'N'),
+        Map.entry(AminoAcid.PROLINE, 'P'),
+        Map.entry(AminoAcid.GLUTAMINE, 'Q'),
+        Map.entry(AminoAcid.ARGININE, 'R'),
+        Map.entry(AminoAcid.SERINE, 'S'),
+        Map.entry(AminoAcid.THREONINE, 'T'),
+        Map.entry(AminoAcid.VALINE, 'V'),
+        Map.entry(AminoAcid.TRYPTOPHAN, 'W'),
+        Map.entry(AminoAcid.TYROSINE, 'Y')
+    );
+
+    static {
+        for (Map.Entry<AminoAcid, Character> entry : LETTER_MAP.entrySet()) {
+            List<String> codons = entry.getKey().getCodonData();
+            for (String codon : codons) {
+                CODON_MAP.put(codon, entry.getValue());
+            }
+        }
+        for (String stop : CodonDataConstants.STOP) {
+            CODON_MAP.put(stop, '*');
+        }
+    }
+
+    private CodonTranslator() {}
+
+    /** Translate a DNA sequence into amino acid single-letter codes. */
+    public static String translate(String dna) {
+        StringBuilder aa = new StringBuilder();
+        String upper = dna.toUpperCase();
+        for (int i = 0; i <= upper.length() - 3; i += 3) {
+            String codon = upper.substring(i, i + 3);
+            aa.append(CODON_MAP.getOrDefault(codon, '?'));
+        }
+        return aa.toString();
+    }
+}

--- a/src/main/java/DNAnalyzer/utils/protein/CodonTranslator.java
+++ b/src/main/java/DNAnalyzer/utils/protein/CodonTranslator.java
@@ -8,52 +8,52 @@ import java.util.Map;
 
 /** Utility to translate DNA codons to amino acid single-letter codes. */
 public class CodonTranslator {
-    private static final Map<String, Character> CODON_MAP = new HashMap<>();
-    private static final Map<AminoAcid, Character> LETTER_MAP = Map.ofEntries(
-        Map.entry(AminoAcid.ALANINE, 'A'),
-        Map.entry(AminoAcid.CYSTEINE, 'C'),
-        Map.entry(AminoAcid.ASPARTIC_ACID, 'D'),
-        Map.entry(AminoAcid.GLUTAMIC_ACID, 'E'),
-        Map.entry(AminoAcid.PHENYLALANINE, 'F'),
-        Map.entry(AminoAcid.GLYCINE, 'G'),
-        Map.entry(AminoAcid.HISTIDINE, 'H'),
-        Map.entry(AminoAcid.ISOLEUCINE, 'I'),
-        Map.entry(AminoAcid.LYSINE, 'K'),
-        Map.entry(AminoAcid.LEUCINE, 'L'),
-        Map.entry(AminoAcid.METHIONINE, 'M'),
-        Map.entry(AminoAcid.ASPARAGINE, 'N'),
-        Map.entry(AminoAcid.PROLINE, 'P'),
-        Map.entry(AminoAcid.GLUTAMINE, 'Q'),
-        Map.entry(AminoAcid.ARGININE, 'R'),
-        Map.entry(AminoAcid.SERINE, 'S'),
-        Map.entry(AminoAcid.THREONINE, 'T'),
-        Map.entry(AminoAcid.VALINE, 'V'),
-        Map.entry(AminoAcid.TRYPTOPHAN, 'W'),
-        Map.entry(AminoAcid.TYROSINE, 'Y')
-    );
+  private static final Map<String, Character> CODON_MAP = new HashMap<>();
+  private static final Map<AminoAcid, Character> LETTER_MAP =
+      Map.ofEntries(
+          Map.entry(AminoAcid.ALANINE, 'A'),
+          Map.entry(AminoAcid.CYSTEINE, 'C'),
+          Map.entry(AminoAcid.ASPARTIC_ACID, 'D'),
+          Map.entry(AminoAcid.GLUTAMIC_ACID, 'E'),
+          Map.entry(AminoAcid.PHENYLALANINE, 'F'),
+          Map.entry(AminoAcid.GLYCINE, 'G'),
+          Map.entry(AminoAcid.HISTIDINE, 'H'),
+          Map.entry(AminoAcid.ISOLEUCINE, 'I'),
+          Map.entry(AminoAcid.LYSINE, 'K'),
+          Map.entry(AminoAcid.LEUCINE, 'L'),
+          Map.entry(AminoAcid.METHIONINE, 'M'),
+          Map.entry(AminoAcid.ASPARAGINE, 'N'),
+          Map.entry(AminoAcid.PROLINE, 'P'),
+          Map.entry(AminoAcid.GLUTAMINE, 'Q'),
+          Map.entry(AminoAcid.ARGININE, 'R'),
+          Map.entry(AminoAcid.SERINE, 'S'),
+          Map.entry(AminoAcid.THREONINE, 'T'),
+          Map.entry(AminoAcid.VALINE, 'V'),
+          Map.entry(AminoAcid.TRYPTOPHAN, 'W'),
+          Map.entry(AminoAcid.TYROSINE, 'Y'));
 
-    static {
-        for (Map.Entry<AminoAcid, Character> entry : LETTER_MAP.entrySet()) {
-            List<String> codons = entry.getKey().getCodonData();
-            for (String codon : codons) {
-                CODON_MAP.put(codon, entry.getValue());
-            }
-        }
-        for (String stop : CodonDataConstants.STOP) {
-            CODON_MAP.put(stop, '*');
-        }
+  static {
+    for (Map.Entry<AminoAcid, Character> entry : LETTER_MAP.entrySet()) {
+      List<String> codons = entry.getKey().getCodonData();
+      for (String codon : codons) {
+        CODON_MAP.put(codon, entry.getValue());
+      }
     }
-
-    private CodonTranslator() {}
-
-    /** Translate a DNA sequence into amino acid single-letter codes. */
-    public static String translate(String dna) {
-        StringBuilder aa = new StringBuilder();
-        String upper = dna.toUpperCase();
-        for (int i = 0; i <= upper.length() - 3; i += 3) {
-            String codon = upper.substring(i, i + 3);
-            aa.append(CODON_MAP.getOrDefault(codon, '?'));
-        }
-        return aa.toString();
+    for (String stop : CodonDataConstants.STOP) {
+      CODON_MAP.put(stop, '*');
     }
+  }
+
+  private CodonTranslator() {}
+
+  /** Translate a DNA sequence into amino acid single-letter codes. */
+  public static String translate(String dna) {
+    StringBuilder aa = new StringBuilder();
+    String upper = dna.toUpperCase();
+    for (int i = 0; i <= upper.length() - 3; i += 3) {
+      String codon = upper.substring(i, i + 3);
+      aa.append(CODON_MAP.getOrDefault(codon, '?'));
+    }
+    return aa.toString();
+  }
 }

--- a/src/test/java/DNAnalyzer/utils/protein/CodonTranslatorTest.java
+++ b/src/test/java/DNAnalyzer/utils/protein/CodonTranslatorTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 class CodonTranslatorTest {
-    @Test
-    void translateSimpleSequence() {
-        String dna = "ATGGAA"; // Met-Glu
-        String aa = CodonTranslator.translate(dna);
-        assertEquals("ME", aa);
-    }
+  @Test
+  void translateSimpleSequence() {
+    String dna = "ATGGAA"; // Met-Glu
+    String aa = CodonTranslator.translate(dna);
+    assertEquals("ME", aa);
+  }
 }

--- a/src/test/java/DNAnalyzer/utils/protein/CodonTranslatorTest.java
+++ b/src/test/java/DNAnalyzer/utils/protein/CodonTranslatorTest.java
@@ -1,0 +1,14 @@
+package DNAnalyzer.utils.protein;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CodonTranslatorTest {
+    @Test
+    void translateSimpleSequence() {
+        String dna = "ATGGAA"; // Met-Glu
+        String aa = CodonTranslator.translate(dna);
+        assertEquals("ME", aa);
+    }
+}


### PR DESCRIPTION
## Summary
- add CodonTranslator utility and OpenReadingFrame record
- extend ReadingFrameAnalyzer with ORF search and translation
- expose new `--orfs` flag in CLI
- document new CLI option
- fix ApiKeyController duplication
- add unit test for CodonTranslator

## Testing
- `./gradlew test` *(fails: ParserTest, DNAToolsTest, SmithWatermanAlignerTest)*

------
https://chatgpt.com/codex/tasks/task_e_68450296f054833293c4d37cfe0ec4fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to display open reading frames (ORFs) with their amino acid translations.
  - ORF results now include frame number, strand direction, start/end positions, nucleotide sequence, and translated amino acids.

- **Documentation**
  - Updated CLI usage documentation to describe the new ORF display option.

- **Tests**
  - Added unit tests to verify DNA codon translation to amino acids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->