### PR TITLE
feat: add Docker Compose setup to build and run everything in containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gradle
+build
+output
+*.md
+docs
+assets
+installer
+sample-plugins
+scripts
+web

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1: build
+FROM eclipse-temurin:17-jdk-jammy AS builder
+
+WORKDIR /app
+
+# Copy Gradle wrapper and dependency declarations first for layer caching
+COPY gradlew gradlew.bat settings.gradle.kts build.gradle ./
+COPY gradle ./gradle
+
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon -q 2>/dev/null || true
+
+# Copy source and build the fat JAR
+COPY src ./src
+
+RUN ./gradlew bootJar --no-daemon -x test
+
+# Stage 2: runtime
+FROM eclipse-temurin:17-jre-jammy
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ Set `OPENAI_API_KEY` (or `AI_PROVIDER=openai` plus the corresponding key) before
 
 Ready to unlock your genomic insights? Begin precision DNA analysis in seconds:
 
+### Docker (easiest — no Java install required)
+
+```bash
+# Clone the repository
+git clone https://github.com/VerisimilitudeX/DNAnalyzer.git
+cd DNAnalyzer
+
+# Build and start everything in containers
+docker compose up --build
+```
+
+| Service | URL |
+|---|---|
+| Web UI | http://localhost:3000 |
+| REST API | http://localhost:8080 |
+| Swagger / API docs | http://localhost:8080/swagger-ui/index.html |
+
+To stop: `docker compose down`
+
+---
+
+### Manual setup
+
 ```bash
 # Clone the repository
 git clone https://github.com/VerisimilitudeX/DNAnalyzer.git

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,10 @@ bootRun {
     mainClass.set('DNAnalyzer.api.ApiApplication')
 }
 
+bootJar {
+    mainClass = 'DNAnalyzer.api.ApiApplication'
+}
+
 publishing {
     repositories {
         maven {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: dnanalyzer:latest
+    container_name: dnanalyzer-api
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  web:
+    image: nginx:alpine
+    container_name: dnanalyzer-web
+    ports:
+      - "3000:80"
+    volumes:
+      - ./web:/usr/share/nginx/html:ro
+    depends_on:
+      - api
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,7 @@ services:
     container_name: dnanalyzer-api
     ports:
       - "8080:8080"
-    environment:
-      - SPRING_PROFILES_ACTIVE=docker
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
 
   web:
     image: nginx:alpine
@@ -24,6 +16,7 @@ services:
       - "3000:80"
     volumes:
       - ./web:/usr/share/nginx/html:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - api
     restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API requests to the Spring Boot container
+    location /api/ {
+        proxy_pass http://api:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Serve static files; fall back to index.html for SPA routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **multi-stage `Dockerfile`** — Stage 1 uses `eclipse-temurin:17-jdk-jammy` to compile the fat JAR via `./gradlew bootJar`; Stage 2 uses the slim JRE image so the final image stays lean.
- Adds **`docker-compose.yml`** with two services:
  - `api` — builds the Spring Boot API from source, exposed on **port 8080**
  - `web` — serves the static frontend via **nginx:alpine** on **port 3000**, with `/api/` requests reverse-proxied to the `api` container (fixes the "API offline / fallback mode" the browser shows when the origin port doesn't match)
- Adds **`nginx.conf`** to proxy `/api/` → `http://api:8080/api/` inside the Docker network so the frontend can reach the backend without CORS or port issues
- Adds **`.dockerignore`** to exclude build artifacts, docs, and other non-essential files from the build context
- Fixes **`build.gradle`** to explicitly set `bootJar.mainClass = 'DNAnalyzer.api.ApiApplication'` — without this the packaged JAR starts the CLI instead of the API server and exits immediately with `Missing required parameter: <fastaPath>`
- Adds a **Docker quickstart section** to the README with a service URL table

## Usage

```bash
# Build and start everything (no Java install required)
docker compose up --build
```

| Service | URL |
|---|---|
| Web UI | http://localhost:3000 |
| REST API | http://localhost:8080 |
| Swagger / API docs | http://localhost:8080/swagger-ui/index.html |

```bash
# Stop
docker compose down
```

## Test plan

- [x] `docker compose build` completes without errors
- [x] `docker compose up` starts both containers
- [x] Spring Boot API starts on port 8080 (verified locally)
- [x] nginx serves the web frontend on port 3000
- [x] Web frontend connects to the API (no "API offline" fallback)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker containerization with multi-stage builds for streamlined deployments.
  * Introduced Docker Compose configuration to orchestrate API and web services.
  * Configured Nginx reverse proxy for routing API requests and serving the web interface.
  * Updated quickstart guide with Docker Compose setup instructions, eliminating Java installation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->